### PR TITLE
Empty meta fields fix; square layout update

### DIFF
--- a/includes/ucf-spotlight-posttype.php
+++ b/includes/ucf-spotlight-posttype.php
@@ -135,43 +135,31 @@ if ( ! class_exists( 'UCF_Spotlight_PostType' ) ) {
 			if ( 'ucf_spotlight' !== $post_type ) return;
 
 			if ( isset( $_POST['ucf_spotlight_layout'] ) ) {
-				// Ensure field is valid.
 				$layout = $_POST['ucf_spotlight_layout'];
-				if ( $layout ) {
-					update_post_meta( $post_id, 'ucf_spotlight_layout', $layout );
-				}
+				update_post_meta( $post_id, 'ucf_spotlight_layout', $layout );
 			}
 
 			if ( isset( $_POST['ucf_spotlight_header'] ) ) {
 				// Ensure field is valid.
 				$header = sanitize_text_field( $_POST['ucf_spotlight_header'] );
-				if ( $header ) {
-					update_post_meta( $post_id, 'ucf_spotlight_header', $header );
-				}
+				update_post_meta( $post_id, 'ucf_spotlight_header', $header );
 			}
 
 			if ( isset( $_POST['ucf_spotlight_copy'] ) ) {
-				// Ensure field is valid.
 				$copy = $_POST['ucf_spotlight_copy'];
-				if ( $copy ) {
-					update_post_meta( $post_id, 'ucf_spotlight_copy', $copy );
-				}
+				update_post_meta( $post_id, 'ucf_spotlight_copy', $copy );
 			}
 
 			if ( isset( $_POST['ucf_spotlight_link_text'] ) ) {
 				// Ensure field is valid.
 				$link_text = sanitize_text_field( $_POST['ucf_spotlight_link_text'] );
-				if ( $link_text ) {
-					update_post_meta( $post_id, 'ucf_spotlight_link_text', $link_text );
-				}
+				update_post_meta( $post_id, 'ucf_spotlight_link_text', $link_text );
 			}
 
 			if ( isset( $_POST['ucf_spotlight_link_url'] ) ) {
 				// Ensure field is valid.
 				$link_url = sanitize_text_field( $_POST['ucf_spotlight_link_url'] );
-				if ( $link_url ) {
-					update_post_meta( $post_id, 'ucf_spotlight_link_url', $link_url );
-				}
+				update_post_meta( $post_id, 'ucf_spotlight_link_url', $link_url );
 			}
 		}
 

--- a/layouts/layout-square.php
+++ b/layouts/layout-square.php
@@ -31,7 +31,7 @@ function ucf_spotlight_display_square( $content='', $item, $args ) {
 					<?php if ( $args['copy'] ) { echo $args['copy']; } ?>
 				</div>
 
-				<?php if ( $args['link_text'] ): ?>
+				<?php if ( $args['link_url'] && $args['link_text'] ): ?>
 				<div class="spotlight-btn-wrapper font-sans-serif mt-auto pt-5">
 					<div class="spotlight-btn btn btn-primary btn-sm p-3">
 						<?php echo $args['link_text']; ?>


### PR DESCRIPTION
- Allow empty spotlight meta to be saved.  Resolves #16.
- Updates square spotlights to not display a faux-button if a link url is not provided.