### PR TITLE
Gracefully handle display logic for nonexistent spotlights

### DIFF
--- a/includes/ucf-spotlight-common.php
+++ b/includes/ucf-spotlight-common.php
@@ -7,16 +7,16 @@ if ( ! class_exists( 'UCF_Spotlight_Common' ) ) {
 	class UCF_Spotlight_Common {
 
 		public static function display_spotlight( $item, $args=array() ) {
-			$args = array_merge( self::get_spotlight_meta( $item->ID ), $args );
-
 			ob_start();
 
-			// Main content/loop
-			$layout_content = ucf_spotlight_display_square( '', $item, $args ); // square=default
-			if ( has_filter( 'ucf_spotlight_display_' . $args['layout'] ) ) {
-				$layout_content = apply_filters( 'ucf_spotlight_display_' . $args['layout'], $layout_content, $item, $args );
+			if ( $item ) {
+				// Main content/loop
+				$layout_content = ucf_spotlight_display_square( '', $item, $args ); // square=default
+				if ( has_filter( 'ucf_spotlight_display_' . $args['layout'] ) ) {
+					$layout_content = apply_filters( 'ucf_spotlight_display_' . $args['layout'], $layout_content, $item, $args );
+				}
+				echo $layout_content;
 			}
-			echo $layout_content;
 
 			return ob_get_clean();
 		}

--- a/includes/ucf-spotlight-common.php
+++ b/includes/ucf-spotlight-common.php
@@ -10,6 +10,8 @@ if ( ! class_exists( 'UCF_Spotlight_Common' ) ) {
 			ob_start();
 
 			if ( $item ) {
+				$args = array_merge( self::get_spotlight_meta( $item->ID ), $args );
+
 				// Main content/loop
 				$layout_content = ucf_spotlight_display_square( '', $item, $args ); // square=default
 				if ( has_filter( 'ucf_spotlight_display_' . $args['layout'] ) ) {


### PR DESCRIPTION
Updated `UCF_Spotlight_Common::display_spotlight()` to only perform display-related logic if an actual spotlight post `$item` was passed in.