### PR TITLE
Remove permalink blank page

### DIFF
--- a/includes/ucf-spotlight-posttype.php
+++ b/includes/ucf-spotlight-posttype.php
@@ -231,7 +231,7 @@ if ( ! class_exists( 'UCF_Spotlight_PostType' ) ) {
 				'can_export'            => true,
 				'has_archive'           => false,
 				'exclude_from_search'   => false,
-				'publicly_queryable'    => true,
+				'publicly_queryable'    => false,
 				'capability_type'       => 'post',
 			);
 			$args = apply_filters( 'ucf_spotlight_post_type_args', $args );

--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,10 @@ The `[ucf-spotlight]` shortcode has one option:
 
 ## Changelog ##
 
+### 2.0.8 ###
+Bug Fixes:
+* Disabled permalink page creation by default
+
 ### 2.0.7 ###
 Documentation:
 * Updated contributing doc to reflect the switch from slack to teams.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: ucfwebcom
 Tags: ucf, spotlights
 Requires at least: 4.7.3
 Tested up to: 5.2.4
-Stable tag: 2.0.7
+Stable tag: 2.0.8
 Requires PHP: 5.4
 License: GPLv3 or later
 License URI: http://www.gnu.org/copyleft/gpl-3.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: ucfwebcom
 Tags: ucf, spotlights
 Requires at least: 4.7.3
-Tested up to: 5.2.4
+Tested up to: 5.5.1
 Stable tag: 2.0.8
 Requires PHP: 5.4
 License: GPLv3 or later
@@ -29,6 +29,10 @@ The `[ucf-spotlight]` shortcode has one option:
 
 
 == Changelog ==
+
+= 2.0.8 =
+Bug Fixes:
+* Disabled permalink page creation by default
 
 = 2.0.7 =
 Documentation:

--- a/ucf-spotlight.php
+++ b/ucf-spotlight.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: UCF Spotlights
 Description: Provides a custom post type, shortcode and functions for displaying Spotlights.
-Version: 2.0.7
+Version: 2.0.8
 Author: UCF Web Communications
 License: GPL3
 GitHub Plugin URI: UCF/UCF-Spotlights-Plugin


### PR DESCRIPTION
<!---
Thank you for contributing to UCF-Spotlights-Plugin.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/UCF-Spotlights-Plugin/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Removes the permalink and blank page created by the custom post type.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Spotlight custom post types created blank pages and permalinks that were searchable. Since spotlights are only used as a shortcode to be used on another page, this blank page is not needed and causes issues with searching and crawling the site.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Tested on my local site and the development site for UCF College of Medicine.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires an update to the documentation.
- [x] I have updated the documentation accordingly.
