### PR TITLE
Spotlight post type indexing and sitemap inclusion fixes

### DIFF
--- a/includes/ucf-spotlight-meta.php
+++ b/includes/ucf-spotlight-meta.php
@@ -15,7 +15,7 @@ function ucf_spotlight_wp_sitemaps( $post_types ) {
 	return $post_types;
 }
 
-add_filter( 'wp_sitemaps_post_types', 'ucf_spotlight_sitemaps', 10, 1 );
+add_filter( 'wp_sitemaps_post_types', 'ucf_spotlight_wp_sitemaps', 10, 1 );
 
 
 /**
@@ -106,7 +106,7 @@ function ucf_spotlight_yoast_accessible_cpt( $post_types ) {
  */
 function ucf_spotlight_yoast_titles( $options ) {
 	// "Show Spotlights in search results?"
-	$options['noindex-ucf_spotlight'] = true;
+	$options['noindex-ucf_spotlight'] = true; // yes this has to be `true` ¯\_(ツ)_/¯
 	// "Yoast SEO Meta Box"
 	$options['display-metabox-pt-ucf_spotlight'] = false;
 

--- a/includes/ucf-spotlight-meta.php
+++ b/includes/ucf-spotlight-meta.php
@@ -1,0 +1,123 @@
+<?php
+
+/**
+ * Removes the Spotlight post type from WP-generated sitemaps.
+ *
+ * @since 2.1.0
+ * @author Jo Dickson
+ * @param array $post_types Array of post type names
+ * @return array
+ */
+function ucf_spotlight_wp_sitemaps( $post_types ) {
+	if ( isset( $post_types['ucf_spotlight'] ) ) {
+		unset( $post_types['ucf_spotlight'] );
+	}
+	return $post_types;
+}
+
+add_filter( 'wp_sitemaps_post_types', 'ucf_spotlight_sitemaps', 10, 1 );
+
+
+/**
+ * Removes the Spotlight post type from Yoast-generated sitemaps.
+ *
+ * @since 2.1.0
+ * @author Jo Dickson
+ * @param bool $excluded Whether or not the given post type should be excluded
+ * @param string $post_type Post type name
+ * @return bool
+ */
+function ucf_spotlight_yoast_sitemaps( $excluded, $post_type ) {
+	if ( $post_type === 'ucf_spotlight' ) {
+		return true;
+	}
+	return $excluded;
+}
+
+add_filter( 'wpseo_sitemap_exclude_post_type', 'ucf_spotlight_yoast_sitemaps', 10, 2 );
+
+
+/**
+ * Appends a noindex,nofollow meta tag to single Spotlights.
+ * For use via `wp_head`.
+ *
+ * @since 2.1.0
+ * @author Jo Dickson
+ * @return void
+ */
+function ucf_spotlight_meta_noindex() {
+	if ( is_singular( 'ucf_spotlight' ) ) :
+?>
+<meta name="robots" content="noindex,nofollow">
+<?php
+	endif;
+}
+
+
+/**
+ * Appends a noindex,nofollow meta tag to single Spotlights.
+ * For use via the `wpseo_robots` hook.
+ *
+ * @since 2.1.0
+ * @author Jo Dickson
+ * @param mixed $robots A meta robots string value, or false
+ * @return mixed
+ */
+function ucf_spotlight_yoast_noindex( $robots ) {
+	if ( is_singular( 'ucf_spotlight' ) ) {
+		return 'noindex,nofollow';
+	}
+	return $robots;
+}
+
+
+/**
+ * Removes Spotlights from Yoast's list of "accessible"
+ * post types (public, indexable).
+ *
+ * @since 2.1.0
+ * @author Jo Dickson
+ * @param array $post_types Array of post type names
+ * @return array
+ */
+function ucf_spotlight_yoast_accessible_cpt( $post_types ) {
+	if ( isset( $post_types['ucf_spotlight'] ) ) {
+		unset( $post_types['ucf_spotlight'] );
+	}
+	return $post_types;
+}
+
+
+/**
+ * Force-toggles Yoast settings in the admin to make it
+ * slightly more obvious that these settings aren't
+ * editable.
+ *
+ * @since 2.1.0
+ * @author Jo Dickson
+ * @param array $options Array of nested option keys/vals
+ * @return array
+ */
+function ucf_spotlight_yoast_titles( $options ) {
+	// "Show Spotlights in search results?"
+	$options['noindex-ucf_spotlight'] = true;
+	// "Yoast SEO Meta Box"
+	$options['display-metabox-pt-ucf_spotlight'] = false;
+
+	return $options;
+}
+
+
+/**
+ * Register filters/actions based on whether or not
+ * Yoast is activated:
+ */
+if ( class_exists( 'WPSEO_Options' ) ) {
+	add_filter( 'wpseo_robots', 'ucf_spotlight_yoast_noindex' );
+	add_filter( 'wpseo_accessible_post_types', 'ucf_spotlight_yoast_accessible_cpt', 10, 1 );
+	add_filter( 'option_wpseo_titles', 'ucf_spotlight_yoast_titles', 10, 1 );
+}
+else {
+	add_action( 'wp_head', 'ucf_spotlight_meta_noindex', 1 );
+}
+

--- a/includes/ucf-spotlight-meta.php
+++ b/includes/ucf-spotlight-meta.php
@@ -15,8 +15,6 @@ function ucf_spotlight_wp_sitemaps( $post_types ) {
 	return $post_types;
 }
 
-add_filter( 'wp_sitemaps_post_types', 'ucf_spotlight_wp_sitemaps', 10, 1 );
-
 
 /**
  * Removes the Spotlight post type from Yoast-generated sitemaps.
@@ -33,8 +31,6 @@ function ucf_spotlight_yoast_sitemaps( $excluded, $post_type ) {
 	}
 	return $excluded;
 }
-
-add_filter( 'wpseo_sitemap_exclude_post_type', 'ucf_spotlight_yoast_sitemaps', 10, 2 );
 
 
 /**
@@ -119,11 +115,13 @@ function ucf_spotlight_yoast_titles( $options ) {
  * Yoast is activated:
  */
 if ( class_exists( 'WPSEO_Options' ) ) {
+	add_filter( 'wpseo_sitemap_exclude_post_type', 'ucf_spotlight_yoast_sitemaps', 10, 2 );
 	add_filter( 'wpseo_robots', 'ucf_spotlight_yoast_noindex' );
 	add_filter( 'wpseo_accessible_post_types', 'ucf_spotlight_yoast_accessible_cpt', 10, 1 );
 	add_filter( 'option_wpseo_titles', 'ucf_spotlight_yoast_titles', 10, 1 );
 }
 else {
+	add_filter( 'wp_sitemaps_post_types', 'ucf_spotlight_wp_sitemaps', 10, 1 );
 	add_action( 'wp_head', 'ucf_spotlight_meta_noindex', 1 );
 }
 

--- a/includes/ucf-spotlight-meta.php
+++ b/includes/ucf-spotlight-meta.php
@@ -39,6 +39,7 @@ add_filter( 'wpseo_sitemap_exclude_post_type', 'ucf_spotlight_yoast_sitemaps', 1
 
 /**
  * Appends a noindex,nofollow meta tag to single Spotlights.
+ *
  * For use via `wp_head`.
  *
  * @since 2.1.0
@@ -56,6 +57,7 @@ function ucf_spotlight_meta_noindex() {
 
 /**
  * Appends a noindex,nofollow meta tag to single Spotlights.
+ *
  * For use via the `wpseo_robots` hook.
  *
  * @since 2.1.0
@@ -75,6 +77,8 @@ function ucf_spotlight_yoast_noindex( $robots ) {
  * Removes Spotlights from Yoast's list of "accessible"
  * post types (public, indexable).
  *
+ * For use via the `wpseo_accessible_post_types` hook.
+ *
  * @since 2.1.0
  * @author Jo Dickson
  * @param array $post_types Array of post type names
@@ -92,6 +96,8 @@ function ucf_spotlight_yoast_accessible_cpt( $post_types ) {
  * Force-toggles Yoast settings in the admin to make it
  * slightly more obvious that these settings aren't
  * editable.
+ *
+ * For use via the `option_wpseo_titles` hook.
  *
  * @since 2.1.0
  * @author Jo Dickson

--- a/includes/ucf-spotlight-templates.php
+++ b/includes/ucf-spotlight-templates.php
@@ -2,7 +2,7 @@
 
 /**
  * Returns a default template for single Spotlights when the
- * current theme (or its parent theme, if applicable) haven't
+ * current theme (or its parent theme, if applicable) hasn't
  * already defined one.
  *
  * @author Jo Dickson

--- a/includes/ucf-spotlight-templates.php
+++ b/includes/ucf-spotlight-templates.php
@@ -7,7 +7,7 @@
  *
  * @author Jo Dickson
  * @since 2.1.0
- **/
+ */
 function ucf_spotlight_template( $template ) {
 	if ( get_query_var( 'post_type' ) === 'ucf_spotlight' && ! is_archive() ) {
 		// Look for a file in theme

--- a/includes/ucf-spotlight-templates.php
+++ b/includes/ucf-spotlight-templates.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Returns a default template for single Spotlights when the
+ * current theme (or its parent theme, if applicable) haven't
+ * already defined one.
+ *
+ * @author Jo Dickson
+ * @since 2.1.0
+ **/
+function ucf_spotlight_template( $template ) {
+	if ( get_query_var( 'post_type' ) === 'ucf_spotlight' && ! is_archive() ) {
+		// Look for a file in theme
+		if ( ! locate_template( 'single-ucf_spotlight.php', false ) ) {
+			$new_template = UCF_SPOTLIGHT__PLUGIN_DIR . 'templates/single-ucf_spotlight.php';
+			if ( file_exists( $new_template ) ) {
+				return $new_template;
+			}
+		}
+	}
+
+	return $template;
+}
+
+add_filter( 'template_include', 'ucf_spotlight_template', 9 );

--- a/templates/single-ucf_spotlight.php
+++ b/templates/single-ucf_spotlight.php
@@ -1,0 +1,19 @@
+<?php get_header(); the_post(); ?>
+
+<?php $layout = get_post_meta( $post->ID, 'ucf_spotlight_layout', true ); ?>
+
+<?php if ( $layout === 'vertical' || $layout === 'square' ): ?>
+<div class="container mb-5">
+	<div class="row">
+		<div class="col-md-6 col-lg-5 col-xl-4">
+<?php endif; ?>
+
+<?php echo do_shortcode( '[ucf-spotlight slug="' . $post->post_name . '"]' ); ?>
+
+<?php if ( $layout === 'vertical' || $layout === 'square' ): ?>
+		</div>
+	</div>
+</div>
+<?php endif; ?>
+
+<?php get_footer(); ?>

--- a/ucf-spotlight.php
+++ b/ucf-spotlight.php
@@ -13,20 +13,23 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-add_action( 'plugins_loaded', function() {
+define( 'UCF_SPOTLIGHT__PLUGIN_FILE', __FILE__ );
+define( 'UCF_SPOTLIGHT__PLUGIN_DIR', plugin_dir_path( UCF_SPOTLIGHT__PLUGIN_FILE ) );
 
-	define( 'UCF_SPOTLIGHT__PLUGIN_FILE', __FILE__ );
+
+add_action( 'plugins_loaded', function() {
 
 	add_image_size( 'ucf-spotlight-horizontal', 1200, 400, false );
 	add_image_size( 'ucf-spotlight-vertical', 360, 360, false );
 	add_image_size( 'ucf-spotlight-square', 767, 767, true );
 
-	require_once 'layouts/layout-square.php';
-	require_once 'layouts/layout-horizontal.php';
-	require_once 'layouts/layout-vertical.php';
-	require_once 'includes/ucf-spotlight-common.php';
-	require_once 'includes/ucf-spotlight-posttype.php';
-	require_once 'shortcodes/ucf-spotlight-shortcode.php';
+	require_once UCF_SPOTLIGHT__PLUGIN_DIR . 'layouts/layout-square.php';
+	require_once UCF_SPOTLIGHT__PLUGIN_DIR . 'layouts/layout-horizontal.php';
+	require_once UCF_SPOTLIGHT__PLUGIN_DIR . 'layouts/layout-vertical.php';
+	require_once UCF_SPOTLIGHT__PLUGIN_DIR . 'includes/ucf-spotlight-common.php';
+	require_once UCF_SPOTLIGHT__PLUGIN_DIR . 'includes/ucf-spotlight-posttype.php';
+	require_once UCF_SPOTLIGHT__PLUGIN_DIR . 'includes/ucf-spotlight-templates.php';
+	require_once UCF_SPOTLIGHT__PLUGIN_DIR . 'shortcodes/ucf-spotlight-shortcode.php';
 
 } );
 

--- a/ucf-spotlight.php
+++ b/ucf-spotlight.php
@@ -29,6 +29,7 @@ add_action( 'plugins_loaded', function() {
 	require_once UCF_SPOTLIGHT__PLUGIN_DIR . 'includes/ucf-spotlight-common.php';
 	require_once UCF_SPOTLIGHT__PLUGIN_DIR . 'includes/ucf-spotlight-posttype.php';
 	require_once UCF_SPOTLIGHT__PLUGIN_DIR . 'includes/ucf-spotlight-templates.php';
+	require_once UCF_SPOTLIGHT__PLUGIN_DIR . 'includes/ucf-spotlight-meta.php';
 	require_once UCF_SPOTLIGHT__PLUGIN_DIR . 'shortcodes/ucf-spotlight-shortcode.php';
 
 } );


### PR DESCRIPTION
<!---
Thank you for contributing to UCF-Spotlights-Plugin.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/UCF-Spotlights-Plugin/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
These changes help prevent single Spotlights from being unintentionally crawled and indexed in search engines, while still allowing them to be preview-able.
- Added a new default template for single Spotlights to allow for previews to function properly if the active theme hasn't already defined one (fixes "blank page" bug when viewing a single Spotlight).
- Added a `<meta name="robots" content="noindex,nofollow">` tag to the document head on single Spotlights.  Supports Yoast if activated.
- Added excludes for Spotlights from sitemaps (WP 5.5+, or Yoast if activated)
- Added some overrides to Yoast settings for Spotlights to force admin toggles to specific values.

Other changes:
- Updated the main plugin file to use absolute paths for `require_once`'s.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves #33 

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Tested locally against WP 5.5.1 (Yoast on and off) and in Dev on 5.3 with Yoast activated.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
